### PR TITLE
Clean up dashboard visuals and styling

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,16 +4,16 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 shadow-sm",
+  "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-gradient-to-r from-blue-400 to-blue-500 text-white hover:from-blue-500 hover:to-blue-600 shadow-md",
+          "border-slate-200 bg-white text-slate-700 hover:bg-slate-50",
         secondary:
-          "border-transparent bg-slate-100 text-slate-700 hover:bg-slate-200",
+          "border-slate-200 bg-slate-50 text-slate-700 hover:bg-slate-100",
         destructive:
-          "border-transparent bg-gradient-to-r from-red-500 to-red-600 text-white hover:from-red-600 hover:to-red-700 shadow-md",
+          "border-slate-200 bg-white text-red-600",
         outline: "text-slate-700 border-slate-200 bg-white hover:bg-slate-50",
       },
     },

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -47,42 +47,42 @@ const AdminDashboard = () => {
       value: stats.totalOrganizations.toString(),
       icon: Building,
       description: "Registered organizations",
-      color: "text-blue-600"
+      color: "text-slate-500"
     },
     {
       title: "Active Organizations",
       value: stats.activeOrganizations.toString(),
       icon: Activity,
       description: "Currently active",
-      color: "text-blue-600"
+      color: "text-slate-500"
     },
     {
       title: "Total Users",
       value: stats.totalUsers.toString(),
       icon: Users,
       description: "Across all organizations",
-      color: "text-blue-600"
+      color: "text-slate-500"
     },
     {
       title: "System Wallet Balance",
       value: `UGX ${stats.totalWalletBalance.toLocaleString()}`,
       icon: DollarSign,
       description: "Total across all orgs",
-      color: "text-blue-600"
+      color: "text-slate-500"
     },
     {
       title: "Monthly Transactions",
       value: stats.monthlyTransactions.toString(),
       icon: TrendingUp,
       description: "This month",
-      color: "text-blue-600"
+      color: "text-slate-500"
     },
     {
       title: "System Alerts",
       value: stats.systemAlerts.toString(),
       icon: AlertTriangle,
       description: "Requires attention",
-      color: "text-blue-600"
+      color: "text-slate-500"
     }
   ];
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -44,37 +44,31 @@ const Dashboard = () => {
     value: stats.totalPayments.toLocaleString(),
     icon: CreditCard,
     description: "All-time bulk payments",
-    color: "text-blue-600"
+    color: "text-slate-500"
   }, {
     title: "Total Amount",
     value: `UGX ${stats.totalAmount.toLocaleString()}`,
     icon: DollarSign,
     description: "Total processed amount",
-    color: "text-green-600"
+    color: "text-slate-500"
   }, {
     title: "Successful",
     value: stats.successfulTransactions.toLocaleString(),
     icon: TrendingUp,
     description: "Completed transactions",
-    color: "text-emerald-600"
+    color: "text-slate-500"
   }, {
     title: "Pending",
     value: stats.pendingTransactions.toLocaleString(),
     icon: Activity,
     description: "Processing transactions",
-    color: "text-orange-600"
+    color: "text-slate-500"
   }, {
     title: "Organizations",
     value: stats.organizations.toLocaleString(),
     icon: Users,
     description: "Active organizations",
-    color: "text-purple-600"
-  }, {
-    title: "Growth",
-    value: `+${stats.monthlyGrowth}%`,
-    icon: TrendingUp,
-    description: "Monthly growth rate",
-    color: "text-cyan-600"
+    color: "text-slate-500"
   }];
   return <DashboardLayout>
       <div className="space-y-4 sm:space-y-6">
@@ -92,7 +86,7 @@ const Dashboard = () => {
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-6 gap-3 sm:gap-4 lg:gap-6">
-          {statCards.map((card, index) => <Card key={index} className="hover:shadow-md transition-shadow">
+          {statCards.map((card, index) => <Card key={index} className="hover:shadow-md transition-shadow border border-slate-100">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-xs sm:text-sm font-medium">
                   {card.title}
@@ -100,13 +94,7 @@ const Dashboard = () => {
                 <card.icon className={`h-3 w-3 sm:h-4 sm:w-4 ${card.color}`} />
               </CardHeader>
               <CardContent>
-                <div className="text-base sm:text-lg lg:text-xl xl:text-2xl font-bold">
-                  {card.title === "Growth" ? (
-                    <span className="hidden sm:inline">{card.value}</span>
-                  ) : (
-                    card.value
-                  )}
-                </div>
+                <div className="text-base sm:text-lg lg:text-xl xl:text-2xl font-bold text-slate-900">{card.value}</div>
                 <CardDescription className="text-xs">
                   {card.description}
                 </CardDescription>

--- a/src/pages/OrgDashboard.tsx
+++ b/src/pages/OrgDashboard.tsx
@@ -112,11 +112,11 @@ const OrgDashboard = () => {
     switch (status) {
       case 'approved':
       case 'completed':
-        return 'bg-blue-50 text-blue-700 border-blue-200';
+        return 'bg-slate-50 text-slate-700 border-slate-200';
       case 'pending':
         return 'bg-slate-50 text-slate-700 border-slate-200';
       case 'rejected':
-        return 'bg-slate-100 text-slate-700 border-slate-200';
+        return 'bg-slate-50 text-slate-700 border-slate-200';
       default:
         return 'bg-slate-50 text-slate-700 border-slate-200';
     }
@@ -280,12 +280,10 @@ const OrgDashboard = () => {
           <Card className="group hover:shadow-lg transition-all duration-200 border border-slate-100 shadow-sm bg-white">
             <CardContent className="p-3 sm:p-4">
               <div className="flex items-center justify-between mb-2">
-              <div className="p-1.5 rounded-lg bg-blue-50 group-hover:bg-blue-100 transition-colors">
-                  <DollarSign className="h-3 w-3 sm:h-4 sm:w-4 text-blue-600" />
+              <div className="p-1.5 rounded-lg bg-slate-100 group-hover:bg-slate-200 transition-colors">
+                  <DollarSign className="h-3 w-3 sm:h-4 sm:w-4 text-slate-600" />
               </div>
-                <Badge className="bg-white/80 text-slate-700 border-slate-200 text-xs px-1.5 py-0.5 hidden sm:inline">
-                  +12.5%
-                </Badge>
+                
             </div>
               <div className="space-y-1">
                 <p className="text-xs font-medium text-slate-600">Collections</p>
@@ -305,20 +303,19 @@ const OrgDashboard = () => {
         <Card className="group hover:shadow-lg transition-all duration-200 border border-slate-100 shadow-sm bg-white">
           <CardContent className="p-3 sm:p-4">
             <div className="flex items-center justify-between mb-2">
-              <div className="p-1.5 rounded-lg bg-blue-50 group-hover:bg-blue-100 transition-colors">
-                <Wallet className="h-3 w-3 sm:h-4 sm:w-4 text-blue-600" />
+              <div className="p-1.5 rounded-lg bg-slate-100 group-hover:bg-slate-200 transition-colors">
+                <Wallet className="h-3 w-3 sm:h-4 sm:w-4 text-slate-600" />
               </div>
-              <Badge className="bg-white/80 text-slate-700 border-slate-200 text-xs px-1.5 py-0.5 hidden sm:inline">-2.1%</Badge>
+              
             </div>
             <div className="space-y-1">
               <p className="text-xs font-medium text-slate-600">Wallet</p>
               <p className="text-sm sm:text-base font-bold text-slate-900">
                 UGX {(dashboardData.walletBalance / 1000000).toFixed(1)}M
               </p>
-              <div className="flex items-center gap-1 text-xs text-blue-700 bg-blue-50 rounded-full px-2 py-1 w-fit">
+              <div className="flex items-center gap-1 text-xs text-slate-600 bg-slate-100 rounded-full px-2 py-1 w-fit">
                 <TrendingDown className="h-2.5 w-2.5" />
                 <span className="hidden sm:inline">from last week</span>
-                <span className="sm:hidden hidden">-2.1%</span>
               </div>
             </div>
           </CardContent>
@@ -328,20 +325,19 @@ const OrgDashboard = () => {
           <Card className="group hover:shadow-lg transition-all duration-200 border border-slate-100 shadow-sm bg-white">
             <CardContent className="p-3 sm:p-4">
               <div className="flex items-center justify-between mb-2">
-                <div className="p-1.5 rounded-lg bg-blue-50 group-hover:bg-blue-100 transition-colors">
-                  <Wallet className="h-3 w-3 sm:h-4 sm:w-4 text-blue-600" />
+                <div className="p-1.5 rounded-lg bg-slate-100 group-hover:bg-slate-200 transition-colors">
+                  <Wallet className="h-3 w-3 sm:h-4 sm:w-4 text-slate-600" />
                 </div>
-                <Badge className="bg-white/80 text-slate-700 border-slate-200 text-xs px-1.5 py-0.5 hidden sm:inline">+5.2%</Badge>
+                
               </div>
               <div className="space-y-1">
                 <p className="text-xs font-medium text-slate-600">Petty Cash</p>
                 <p className="text-sm sm:text-base font-bold text-slate-900">
                   UGX {(dashboardData.pettyCashBalance / 1000).toFixed(0)}K
                 </p>
-                <div className="flex items-center gap-1 text-xs text-blue-700 bg-blue-50 rounded-full px-2 py-1 w-fit">
+                <div className="flex items-center gap-1 text-xs text-slate-600 bg-slate-100 rounded-full px-2 py-1 w-fit">
                   <TrendingUp className="h-2.5 w-2.5" />
                   <span className="hidden sm:inline">from last week</span>
-                  <span className="sm:hidden hidden">+5.2%</span>
                 </div>
               </div>
             </CardContent>
@@ -351,20 +347,19 @@ const OrgDashboard = () => {
           <Card className="group hover:shadow-lg transition-all duration-200 border border-slate-100 shadow-sm bg-white">
             <CardContent className="p-3 sm:p-4">
               <div className="flex items-center justify-between mb-2">
-                <div className="p-1.5 rounded-lg bg-blue-50 group-hover:bg-blue-100 transition-colors">
-                  <Activity className="h-3 w-3 sm:h-4 sm:w-4 text-blue-600" />
+                <div className="p-1.5 rounded-lg bg-slate-100 group-hover:bg-slate-200 transition-colors">
+                  <Activity className="h-3 w-3 sm:h-4 sm:w-4 text-slate-600" />
                 </div>
-                <Badge className="bg-white/80 text-slate-700 border-slate-200 text-xs px-1.5 py-0.5 hidden sm:inline">+18.1%</Badge>
+                
               </div>
               <div className="space-y-1">
                 <p className="text-xs font-medium text-slate-600">Transactions</p>
                 <p className="text-sm sm:text-base font-bold text-slate-900">
                   {dashboardData.monthlyTransactions}
                 </p>
-                <div className="flex items-center gap-1 text-xs text-blue-700 bg-blue-50 rounded-full px-2 py-1 w-fit">
+                <div className="flex items-center gap-1 text-xs text-slate-600 bg-slate-100 rounded-full px-2 py-1 w-fit">
                   <TrendingUp className="h-2.5 w-2.5" />
                   <span className="hidden sm:inline">from last month</span>
-                  <span className="sm:hidden hidden">+18.1%</span>
                 </div>
               </div>
             </CardContent>
@@ -447,7 +442,7 @@ const OrgDashboard = () => {
                       </div>
                       <CardTitle className="text-sm font-semibold text-slate-900">Pending Approvals</CardTitle>
                     </div>
-                    <Badge className="bg-blue-600 text-white shadow-sm text-xs">
+                    <Badge className="text-xs">
                       {dashboardData.pendingApprovals}
                     </Badge>
                   </div>
@@ -456,20 +451,20 @@ const OrgDashboard = () => {
                   <div className="space-y-1.5 sm:space-y-2">
                     <div className="flex justify-between items-center p-2 rounded-lg bg-white/60 border border-slate-100">
                       <div className="flex items-center gap-2">
-                        <div className="w-1.5 h-1.5 rounded-full bg-blue-600"></div>
+                        <div className="w-1.5 h-1.5 rounded-full bg-slate-400"></div>
                         <span className="text-xs font-medium text-slate-700">Transactions</span>
                       </div>
-                      <Badge className="bg-blue-50 text-blue-700 border-blue-200 text-xs">5</Badge>
+                      <Badge className="text-xs">5</Badge>
                     </div>
                     <div className="flex justify-between items-center p-2 rounded-lg bg-white/60 border border-slate-100">
                       <div className="flex items-center gap-2">
-                        <div className="w-1.5 h-1.5 rounded-full bg-blue-600"></div>
+                        <div className="w-1.5 h-1.5 rounded-full bg-slate-400"></div>
                         <span className="text-xs font-medium text-slate-700">Funding</span>
                       </div>
-                      <Badge className="bg-blue-50 text-blue-700 border-blue-200 text-xs">3</Badge>
+                      <Badge className="text-xs">3</Badge>
                     </div>
                   </div>
-                  <Button className="w-full bg-blue-600 hover:bg-blue-700 shadow-sm h-7 sm:h-8 text-xs">
+                  <Button className="w-full h-7 sm:h-8 text-xs">
                     <CheckCircle className="h-3 w-3 mr-2" />
                     Review All
                   </Button>

--- a/src/pages/OrganizationDashboard.tsx
+++ b/src/pages/OrganizationDashboard.tsx
@@ -55,28 +55,28 @@ const OrganizationDashboard = () => {
       value: orgStats.totalPayments.toString(),
       icon: CreditCard,
       description: "This month",
-      color: "text-purple-600"
+      color: "text-slate-500"
     },
     {
       title: "Successful",
       value: orgStats.successfulTransactions.toString(),
       icon: TrendingUp,
       description: "Completed transactions",
-      color: "text-emerald-600"
+      color: "text-slate-500"
     },
     {
       title: "Pending",
       value: orgStats.pendingTransactions.toString(),
       icon: Activity,
       description: "Awaiting processing",
-      color: "text-orange-600"
+      color: "text-slate-500"
     },
     {
       title: "Sub-Admins",
       value: orgStats.subAdmins.toString(),
       icon: Users,
       description: "Active team members",
-      color: "text-cyan-600"
+      color: "text-slate-500"
     }
   ];
 


### PR DESCRIPTION
Remove percentage displays from dashboard cards and neutralize status badge colors for a cleaner, more subtle UI.

The previous dashboard styling, with prominent percentages and bright status badge colors, was visually overwhelming. This PR adopts a more neutral, professional aesthetic, inspired by platforms like PayPal, to improve readability and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-49c939d6-fee1-4f63-9edd-590193bede2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49c939d6-fee1-4f63-9edd-590193bede2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

