### PR TITLE
Investigate login security and fix username login error

### DIFF
--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -75,11 +75,11 @@ class AuthService {
     const response = await fetch(`${API_BASE_URL}/auth/login/`, {
       method: "POST",
       headers,
-      body: JSON.stringify({
-        username: credentials.username,
-        email: credentials.email,
-        password: credentials.password
-      })
+      body: JSON.stringify(
+        credentials.username
+          ? { username: credentials.username, password: credentials.password }
+          : { email: credentials.email, password: credentials.password }
+      )
     });
 
     if (!response.ok) {
@@ -106,13 +106,7 @@ class AuthService {
     // Derive role from token if available; fallback to staff
     const claims = accessToken ? this.decodeJwt(accessToken) : null;
     const derivedRole = (claims?.role?.toLowerCase?.()) || 'staff';
-    const isKnownAdmin = (
-      (credentials.email && ["ladsondave84@gmail.com"].includes((credentials.email || '').toLowerCase())) ||
-      (credentials.username && ["david.ladson"].includes((credentials.username || '').toLowerCase()))
-    );
-    const role = isKnownAdmin
-      ? 'admin'
-      : (['admin', 'manager', 'staff'] as const).includes(derivedRole) ? derivedRole : 'staff';
+    const role = (['admin', 'manager', 'staff'] as const).includes(derivedRole) ? derivedRole : 'staff';
 
     // Build user profile with permissions by role
     const userProfile = {


### PR DESCRIPTION
Remove hardcoded admin override and fix username login by adjusting the payload.

The previous implementation hardcoded specific admin emails/usernames, bypassing backend role checks. This PR ensures admin access is solely determined by the backend-issued token's role claim. Additionally, the login payload was sending an empty `email` field when a `username` was provided, causing a "email field cannot be empty" error from the backend. The payload now correctly sends either `username` or `email` but not both, preventing this error.

---
<a href="https://cursor.com/background-agent?bcId=bc-adeb5edc-b706-4a3a-bd73-ac7aa264a6eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-adeb5edc-b706-4a3a-bd73-ac7aa264a6eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

