### PR TITLE
Set fallback URL to bulksrv

### DIFF
--- a/src/components/PaymentLinkForm.tsx
+++ b/src/components/PaymentLinkForm.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
+import { API_CONFIG } from "@/services/api-config";
 
 interface PaymentLinkFormProps {
   onSuccess: () => void;
@@ -33,7 +34,7 @@ const PaymentLinkForm = ({ onSuccess }: PaymentLinkFormProps) => {
     
     try {
       const token = localStorage.getItem("auth_token");
-      const response = await fetch("https://bulksrv.almaredagencyuganda.com/payments/mobile-money/initiate-collection/", {
+      const response = await fetch(`${API_CONFIG.baseURL}payments/mobile-money/initiate-collection/`, {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${token}`,

--- a/src/pages/OrgCollections.tsx
+++ b/src/pages/OrgCollections.tsx
@@ -16,6 +16,7 @@ import { Link } from "react-router-dom";
 const PaymentLinkForm = lazy(() => import("@/components/PaymentLinkForm"));
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
+import { API_CONFIG } from "@/services/api-config";
 
 interface Collection {
   id: string;
@@ -87,7 +88,7 @@ const Collections = () => {
     try {
       setIsLoading(true);
       const token = localStorage.getItem("auth_token");
-      const response = await fetch("https://bulksrv.almaredagencyuganda.com/payments/collections/", {
+      const response = await fetch(`${API_CONFIG.baseURL}payments/collections/`, {
         headers: {
           "Authorization": `Bearer ${token}`,
           "Content-Type": "application/json",
@@ -201,7 +202,7 @@ const Collections = () => {
 
     try {
       const token = localStorage.getItem("auth_token");
-      const response = await fetch("https://bulksrv.almaredagencyuganda.com/payments/mobile-money/initiate-collection/", {
+      const response = await fetch(`${API_CONFIG.baseURL}payments/mobile-money/initiate-collection/`, {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${token}`,


### PR DESCRIPTION
Refactor hardcoded API URLs to use `API_CONFIG.baseURL` for centralized configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-f86226a7-bf9e-4282-8d27-02a9070931f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f86226a7-bf9e-4282-8d27-02a9070931f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

