### PR TITLE
Redirect superuser to admin dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const AppRoutes = () => {
             <SystemAdminLayout />
           </ProtectedRoute>
         }>
-          <Route index element={<Navigate to="/system/analytics" replace />} />
+          <Route index element={<Navigate to="/system/organizations" replace />} />
           <Route path="analytics" element={<SystemAnalytics />} />
           <Route path="organizations" element={<SystemOrganizations />} />
           <Route path="users" element={<SystemUsers />} />
@@ -149,7 +149,7 @@ const AppRoutes = () => {
         <Route path="/dashboard" element={
           isAuthenticated ? (
             (user?.role === 'admin' || user?.permissions?.includes('system_admin')) ?
-              <Navigate to="/system/analytics" replace /> :
+              <Navigate to="/system/organizations" replace /> :
               <Navigate to="/org/dashboard" replace />
           ) : (
             <Navigate to="/login" replace />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -37,8 +37,8 @@ const Login = () => {
         const userStr = localStorage.getItem('user');
         if (userStr) {
           const user = JSON.parse(userStr);
-          if (user.role === 'admin') {
-            navigate('/system/analytics');
+          if (user.role === 'admin' || user.permissions?.includes('system_admin')) {
+            navigate('/system/organizations');
           } else {
             navigate('/org/dashboard');
           }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -199,7 +199,7 @@ class AuthService {
       }
 
       // Fetch complete user details
-      const userResponse = await fetch(`${API_CONFIG.baseURL}user/${userId}/`, {
+      const userResponse = await fetch(`${API_CONFIG.baseURL}${API_CONFIG.endpoints.user.userDetail(String(userId))}`, {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',


### PR DESCRIPTION
Redirect superusers to the system admin organizations page after login and update the user profile fetch endpoint.

This change ensures that users with `is_superuser=true` (mapped to 'admin' role or 'system_admin' permission) are automatically directed to the administrative dashboard, specifically the organizations list, upon successful login, fulfilling the requirement to manage organizations and users. It also corrects the API endpoint used to fetch full user details, ensuring `is_superuser` and other permissions are reliably retrieved for routing decisions.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ea2afaa-59b7-45d6-9567-25f5329b789e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ea2afaa-59b7-45d6-9567-25f5329b789e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

