### PR TITLE
Implement account and super user management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,6 +134,7 @@ const AppRoutes = () => {
               <OrgCollectionsReport />
             </ProtectedRoute>
           } />
+          <Route path="account" element={<OrgAccount />} />
           <Route path="settings" element={<OrgSettings />} />
           <Route path="bulk-payments-demo" element={<OrgBulkPaymentsDemo />} />
           <Route path="security-demo" element={<OrgSecurityDemo />} />

--- a/src/components/OrganizationLayout.tsx
+++ b/src/components/OrganizationLayout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -14,6 +15,10 @@ const OrganizationLayout = () => {
     user,
     logout
   } = useAuth();
+  // Redirect system admins to the system dashboard
+  if (user?.role === 'admin') {
+    return <Navigate to="/system/organizations" replace />;
+  }
   const getRoleBadgeVariant = (role: string) => {
     switch (role) {
       case "manager":


### PR DESCRIPTION
Add `/org/account` route for user account management and redirect super users to their dedicated system dashboard.

Super users now have a distinct dashboard for managing organizations and users, preventing them from accessing the organization-specific dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f458df8-896b-4a97-8dbd-51df449e9a2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f458df8-896b-4a97-8dbd-51df449e9a2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

