### PR TITLE
Configure super admin dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,11 @@ const OrganizationLayout = lazy(() => import("./components/OrganizationLayout"))
 const Index = lazy(() => import("./pages/Index"));
 const Login = lazy(() => import("./pages/Login"));
 const AuthTest = lazy(() => import("./pages/AuthTest"));
-const SystemAnalytics = lazy(() => import("./pages/SystemAnalytics"));
+// Removed: SystemAnalytics
 const SystemOrganizations = lazy(() => import("./pages/SystemOrganizations"));
 const SystemUsers = lazy(() => import("./pages/SystemUsers"));
 const SystemSettings = lazy(() => import("./pages/SystemSettings"));
-const SystemAlerts = lazy(() => import("./pages/SystemAlerts"));
+// Removed: SystemAlerts
 const OrgDashboard = lazy(() => import("./pages/OrgDashboard"));
 const OrgPettyCash = lazy(() => import("./pages/OrgPettyCash"));
 const OrgBulkPayments = lazy(() => import("./pages/OrgBulkPayments"));
@@ -69,15 +69,17 @@ const AppRoutes = () => {
 
         {/* System Admin Routes */}
         <Route path="/system" element={
-          <ProtectedRoute requiredRole="admin" fallbackRoute="/login">
-            <SystemAdminLayout />
+          <ProtectedRoute fallbackRoute="/login">
+            {(user?.role === 'admin' || user?.permissions?.includes('system_admin')) ? (
+              <SystemAdminLayout />
+            ) : (
+              <Navigate to="/unauthorized" replace />
+            )}
           </ProtectedRoute>
         }>
           <Route index element={<Navigate to="/system/organizations" replace />} />
-          <Route path="analytics" element={<SystemAnalytics />} />
           <Route path="organizations" element={<SystemOrganizations />} />
           <Route path="users" element={<SystemUsers />} />
-          <Route path="alerts" element={<SystemAlerts />} />
           <Route path="settings" element={<SystemSettings />} />
         </Route>
 

--- a/src/components/AppSystemSidebar.tsx
+++ b/src/components/AppSystemSidebar.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { Sidebar, SidebarContent, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
-import { BarChart3, Building2, Users, Settings, Shield, AlertTriangle, Crown } from "lucide-react";
+import { Building2, Users, Settings, Crown } from "lucide-react";
 
 const adminItems = [
-  { title: "Analytics", url: "/system/analytics", icon: BarChart3 },
   { title: "Organizations", url: "/system/organizations", icon: Building2 },
   { title: "Users", url: "/system/users", icon: Users },
-  { title: "Alerts", url: "/system/alerts", icon: AlertTriangle },
   { title: "Settings", url: "/system/settings", icon: Settings },
 ];
 


### PR DESCRIPTION
Redirect super admins to the `/system` dashboard and trim its content to only organizations, users, and settings.

The `ProtectedRoute` for `/system` was updated to allow access for users with either the `admin` role or the `system_admin` permission, ensuring super admins are correctly routed. Unnecessary `SystemAnalytics` and `SystemAlerts` routes and sidebar items were removed to align with the specified scope of the general admin dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-0526f8c7-e110-436d-92a7-bbb104c50d42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0526f8c7-e110-436d-92a7-bbb104c50d42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

